### PR TITLE
Limit should not be incremented when paging

### DIFF
--- a/lib/elasticsearch/storage/data_stream.ex
+++ b/lib/elasticsearch/storage/data_stream.ex
@@ -60,11 +60,10 @@ defmodule Elasticsearch.DataStream do
       [] ->
         {:halt, {[], offset, limit}}
 
-      # If the load returns items, then return the first item, and put the
-      # tail into the state. Also, increment offset and limit by the
-      # configured `:bulk_page_size`.
+      # If the load returns items, then return the first item, and put the tail
+      # into the state. Also, increment offset by the configured `:bulk_page_size`.
       [h | t] ->
-        {[h], {t, offset + page_size, limit + page_size}}
+        {[h], {t, offset + page_size, limit}}
     end
   end
 


### PR DESCRIPTION
The `limit` argument should not be incremented while paging. I'm using Ecto queries to grab the data, but I think the `limit` param should not increment regardless of what backing-store someone is using.

With `bulk_page_size` set to 1000, the following SQL queries were being made.

```sql
SELECT a0."id", a0."barcode" FROM "assets" AS a0 ORDER BY a0."id" LIMIT $1 OFFSET $2 [1000, 0]
SELECT a0."id", a0."barcode" FROM "assets" AS a0 ORDER BY a0."id" LIMIT $1 OFFSET $2 [2000, 1000]
SELECT a0."id", a0."barcode" FROM "assets" AS a0 ORDER BY a0."id" LIMIT $1 OFFSET $2 [3000, 2000]
```

Which results in overlapping pages:

* First query returns items 0 to 1000
* Second query returns items 1000 to 3000
* Third query returns items 2000 to 5000

Items 2000 to 3000 were being indexed twice, with ElasticSearch throwing a `version conflict, document already exists (current version [1])` error.