### PR TITLE
rely on Config.json_library/1

### DIFF
--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -4,6 +4,7 @@ defmodule Elasticsearch.Index.Bulk do
   """
 
   alias Elasticsearch.{
+    Config,
     DataStream,
     Document
   }
@@ -57,7 +58,7 @@ defmodule Elasticsearch.Index.Bulk do
     document =
       struct
       |> Document.encode()
-      |> Poison.encode!()
+      |> Config.json_library().encode!()
 
     "#{header}\n#{document}\n"
   end
@@ -113,7 +114,7 @@ defmodule Elasticsearch.Index.Bulk do
       |> Map.put(type, attrs)
       |> put_parent(type, struct)
 
-    Poison.encode!(header)
+    Config.json_library().encode!(header)
   end
 
   defp put_parent(header, type, struct) do


### PR DESCRIPTION
first of, i know that this can't be merged as is .. i've based this patch on `v0.1.1`, because i'm not using `v0.2.0` and the included Cluster stuff yet. but it should be easy to port, so this is merely a reminder.

i hit this while working on a reproduction case for #10 where i started a new project w/o any previous dependencies, installed and configured Jason as my library to use (by setting `config :elasticsearch, json_library: Jason`)

which replies with a friendly

```bash
# mix elasticsearch.build posts

** (UndefinedFunctionError) function Poison.encode!/1 is undefined (module Poison is not available)
    Poison.encode!(%{"create" => %{"_id" => 1, "_index" => "posts-1524145047", "_type" => "post"}})
    (elasticsearch) lib/elasticsearch/indexing/bulk.ex:55: Elasticsearch.Index.Bulk.encode!/2
    (elixir) lib/stream.ex:550: anonymous fn/4 in Stream.map/2
    (elixir) lib/stream.ex:1363: Stream.do_resource/5
    (elixir) lib/stream.ex:1536: Enumerable.Stream.do_each/4
    (elixir) lib/enum.ex:1911: Enum.reduce/3
    (elasticsearch) lib/elasticsearch/indexing/bulk.ex:81: Elasticsearch.Index.Bulk.upload/4
    (elasticsearch) lib/elasticsearch/indexing/index.ex:33: Elasticsearch.Index.hot_swap/4
```
because the libraries dependencies in `mix.exs` declare `Poison` as `optional` - because we allow to use another json library, but at those points the bulk handling relies on `Poison` .. which, well .. is not available.