### PR TITLE
include store in upload parameters

### DIFF
--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -80,7 +80,7 @@ defmodule Elasticsearch.Index.Bulk do
       |> Stream.map(&Elasticsearch.put("/#{index_name}/_bulk", Enum.join(&1)))
       |> Enum.reduce(errors, &collect_errors/2)
 
-    upload(index_name, tail, errors)
+    upload(index_name, store, tail, errors)
   end
 
   defp collect_errors({:ok, %{"errors" => true} = response}, errors) do


### PR DESCRIPTION
[!] same as for #17 - it's based on `v0.1.1`

i was curious because we've had a bunch of `Bulk.collect_errors/2` functions which actually handled the faulty response we're seeing in #10 .. but it didn't stop the stream. going a little bit back and forth i've hit the call to `Bulk.upload/4` which only had three parameters in there.

i'd say we're definitely missing the `store` as second parameter, don't we? 

@aphillipo would you mind giving it a try? a second pair of eyes might be good on this. 
@danielberkompas i'm not sure if i break something else with this, to me everything looks okay. WDYT?