### PR TITLE
improve readability for code-blocks in upgrading guides

### DIFF
--- a/guides/upgrading/0.1.x_to_0.2.x.md
+++ b/guides/upgrading/0.1.x_to_0.2.x.md
@@ -50,17 +50,14 @@ Next, switch over your `:elasticsearch` configuration over to your
 application, and include the cluster. Be sure to rename the `:api_module`
 option to `:api`. See `Elasticsearch.Cluster` for more options.
 
-    # BEFORE
-    config :elasticsearch,
-      url: "http://localhost:9200",
-      api_module: Elasticsearch.API.HTTP,
-      # ...
-
-    # AFTER
-    config, :my_app, MyApp.ElasticsearchCluster,
-      url: "http://localhost:9200",
-      api: Elasticsearch.API.HTTP,
-      # ...
+```diff
+-config :elasticsearch,
++config, :my_app, MyApp.ElasticsearchCluster,
+   url: "http://localhost:9200",
+-  api_module: Elasticsearch.API.HTTP,
++  api: Elasticsearch.API.HTTP,
+   # ...
+```
 
 Next, be sure to start your Cluster in your application supervisor:
 
@@ -70,33 +67,25 @@ Next, be sure to start your Cluster in your application supervisor:
 
 Next, add your cluster to all calls to `Elasticsearch` functions:
 
-    # BEFORE
-    Elasticsearch.post("/posts/_search", %{...})
-
-    # AFTER
-    Elasticsearch.post(MyApp.ElasticsearchCluster, "/posts/_search", %{...})
+```diff
+- Elasticsearch.post("/posts/_search", %{...})
++ Elasticsearch.post(MyApp.ElasticsearchCluster, "/posts/_search", %{...})
+```
 
 Next, update any mock implementations of `Elasticsearch.API` to implement the
 `request/5` function instead of the previous functions.
 
-    # BEFORE
-    defmodule MyApp.ElasticsearchMock do
-      @behaviour Elasticsearch.API
+```diff
+ defmodule MyApp.ElasticsearchMock do
+   @behaviour Elasticsearch.API
 
-      def get("/url", _opts) do
-        {:ok, %HTTPoison.Response{}}
-      end
-    end
-
-    # AFTER
-    defmodule MyApp.ElasticsearchMock do
-      @behaviour Elasticsearch.API
-
-      @impl true
-      def request(_config, :get, "/url", _data, _opts) do
-        {:ok, %HTTPoison.Response{}}
-      end
-    end
+-  def get("/url", _opts) do
++  @impl true
++  def request(_config, :get, "/url", _data, _opts) do
+     {:ok, %HTTPoison.Response{}}
+   end
+ end
+ ```
 
 Finally, update any calls to `mix elasticsearch.build` to include the cluster
 as an option:

--- a/guides/upgrading/0.2.x_to_0.3.x.md
+++ b/guides/upgrading/0.2.x_to_0.3.x.md
@@ -46,68 +46,40 @@ See [infinitered/elasticsearch-elixir#10](https://github.com/infinitered/elastic
 First, remove `type` and `parent` definitions from all your implementations
 of `Elasticsearch.Document`:
 
-    # BEFORE
-    defimpl Elasticsearch.Document, for: MyApp.Struct do
-      def type(struct), do: "struct"
-      def parent(_struct), do: false
-      def id(struct), do: struct.id
-      def encode(struct) do
-        %{
-          # ...
-        }
-      end
-    end
-
-    # AFTER
-    defimpl Elasticsearch.Document, for: MyApp.Struct do
-      def id(struct), do: struct.id
-      def encode(struct) do
-        %{
-          # ...
-        }
-      end
-    end
+```diff
+ defimpl Elasticsearch.Document, for: MyApp.Struct do
+-  def type(struct), do: "struct"
+-  def parent(_struct), do: false
+   def id(struct), do: struct.id
+   def encode(struct) do
+     %{
+```
 
 Next, if you call `Bulk.encode` functions manually, be sure to pass your
 cluster into them.
 
-    # BEFORE
-    Bulk.encode(%MyApp.Struct{}, "index_name")
-
-    # AFTER
-    Bulk.encode(MyApp.ElasticsearchCluster, %MyApp.Struct{}, "index_name")
+```diff
+- Bulk.encode(%MyApp.Struct{}, "index_name")
++ Bulk.encode(MyApp.ElasticsearchCluster, %MyApp.Struct{}, "index_name")
+```
 
 Next, update your index structure to no longer have multiple types per index
 in your index settings `.json` files. Also, rename your type to `_doc`.
 
-    # BEFORE
-    {
-      "mappings": {
-        "post": {
-          "properties": {
-            "title": {
-              "type": "text"
-            },
-            "author": {
-              "type": "text"
-            }
-          }
-        }
-      }
-    }
-
-    # AFTER
-    {
-      "mappings": {
-        "_doc": {
-          "properties": {
-            "title": {
-              "type": "text"
-            },
-            "author": {
-              "type": "text"
-            }
-          }
-        }
-      }
-    }
+```diff
+ {
+   "mappings": {
+-    "post": {
++    "_doc": {
+       "properties": {
+         "title": {
+           "type": "text"
+         },
+         "author": {
+           "type": "text"
+         }
+       }
+     }
+   }
+ }
+```


### PR DESCRIPTION
instead of using those `BEFORE` and `AFTER` blocks, i propose that we're using typical diffs that everyone should be able to read. especially for the larger blocks it's sometimes hard to spot the difference between before and after.