### PR TITLE
Add `priv` dir when packaging application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule Elasticsearch.Mixfile do
         LICENSE
         README.md
         mix.exs
+        priv
       ),
       maintainers: ["Daniel Berkompas"],
       licenses: ["MIT"],


### PR DESCRIPTION
The `priv` directory is not being packaged to hex.pm
Added it in the `mix.exs` file.
Fixes #23 