### PR TITLE
Add breaking change upgrade to documentation

### DIFF
--- a/guides/upgrading/0.3.x_to_0.4.x.md
+++ b/guides/upgrading/0.3.x_to_0.4.x.md
@@ -12,6 +12,8 @@ This makes it easier to have different bulk settings for different indexes.
 **BREAKING**: `:bulk_page_size` and `:bulk_wait_interval` are now configured
 on the index, not the cluster.
 
+`Elasticsearch.Index.hot_swap/5` is now `Elasticsearch.Index.hot_swap/3` where options are passed as a map.
+
 **FEATURE**: You can now pass `--bulk-wait-interval` and `--bulk-page-size`
 options to `mix elasticsearch.build`, as requested in [#26](https://github.com/infinitered/elasticsearch-elixir/issues/26).
 
@@ -53,3 +55,11 @@ rather than your entire cluster.
           bulk_wait_interval: 0
         }
       }
+
+Change the `Elasticsearch.Index.hot_swap/5` call to `Elasticsearch.Index.hot_swap/3`
+
+    # BEFORE
+    Elasticsearch.Index.hot_swap(MyApp.Cluster, "index-name", "path/to/settings", MyApp.Store, [MyApp.Source])
+
+    # AFTER
+    Elasticsearch.Index.hot_swap(MyApp.Cluster, "index-name", %{settings: "path/to/settings", store: MyApp.Store, sources: [MyApp.Source]})


### PR DESCRIPTION
Add documentation to change `Elasticsearch.Index.hot_swap/5` call to `Elasticsearch.Index.hot_swap/3` as it was changed in #27 