### PR TITLE
Support document-not-found error via Get API

### DIFF
--- a/lib/elasticsearch/exception.ex
+++ b/lib/elasticsearch/exception.ex
@@ -59,6 +59,17 @@ defmodule Elasticsearch.Exception do
     ]
   end
 
+  defp build(%{"found" => false}, query) do
+    [
+      status: nil,
+      line: nil,
+      col: nil,
+      message: nil,
+      type: "document_not_found",
+      query: query
+    ]
+  end
+
   defp build(error, query) when is_binary(error) do
     binary_error(error, query)
   end

--- a/test/elasticsearch/exception_test.exs
+++ b/test/elasticsearch/exception_test.exs
@@ -44,5 +44,20 @@ defmodule Elasticsearch.ExceptionTest do
                  query: nil
                )
     end
+
+    # See issue: https://github.com/infinitered/elasticsearch-elixir/issues/33
+    @tag :regression
+    test "understands the document_not_found error" do
+      assert %Exception{type: "document_not_found", message: nil, query: nil} =
+               Exception.exception(
+                 response: %{
+                   "_id" => "123",
+                   "_index" => "index-name",
+                   "_type" => "_doc",
+                   "found" => false
+                 },
+                 query: nil
+               )
+    end
   end
 end


### PR DESCRIPTION
Closes #33 