### PR TITLE
[#43] Stop sending empty JSON payloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ elixir:
   - 1.7.2
 otp_release:
   - 20.1
+env:
+  - ELASTICSEARCH_VERSION=6.2.4
+  - ELASTICSEARCH_VERSION=6.4.0
 services:
   - elasticsearch
 before_install:
-  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.deb 
-  - sudo dpkg -i --force-confnew elasticsearch-6.2.4.deb 
-  - sudo service elasticsearch restart
+  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.deb && sudo dpkg -i --force-confnew elasticsearch-${ELASTICSEARCH_VERSION}.deb && sudo service elasticsearch restart
 before_script:
   - sleep 10
 script:

--- a/lib/elasticsearch/api/http.ex
+++ b/lib/elasticsearch/api/http.ex
@@ -28,13 +28,17 @@ defmodule Elasticsearch.API.HTTP do
   end
 
   # Converts the request body into JSON, unless it has already
-  # been converted
+  # been converted. If the data is empty, sends ""
   defp process_request_body(data, _config) when is_binary(data) do
     data
   end
 
-  defp process_request_body(data, config) when is_map(data) do
+  defp process_request_body(data, config) when is_map(data) and data != %{} do
     json_library(config).encode!(data)
+  end
+
+  defp process_request_body(_data, _config) do
+    ""
   end
 
   # Converts the response body string from JSON into a map, if it looks like it


### PR DESCRIPTION
Elasticsearch 6.4.x apparently stopped accepting empty JSON payloads,
according to #43. This updates `Elasticsearch.API.HTTP` to send `""`
instead of `"{}"` with empy payloads.

Fixes #43.