### PR TITLE
convert index alias to microseconds

### DIFF
--- a/lib/elasticsearch/indexing/index.ex
+++ b/lib/elasticsearch/indexing/index.ex
@@ -287,6 +287,6 @@ defmodule Elasticsearch.Index do
   end
 
   defp system_timestamp do
-    DateTime.to_unix(DateTime.utc_now())
+    DateTime.to_unix(DateTime.utc_now(), :microseconds)
   end
 end


### PR DESCRIPTION
Because the index name is now tied to a particular second, when testing a module that uses elasticsearch-elixir, the index name will collide.
Changed to microsecond.