### PR TITLE
Delete the right index

### DIFF
--- a/lib/elasticsearch/indexing/index.ex
+++ b/lib/elasticsearch/indexing/index.ex
@@ -58,12 +58,13 @@ defmodule Elasticsearch.Index do
           | {:error, Elasticsearch.Exception.t()}
   def starting_with(cluster, prefix) do
     with {:ok, indexes} <- Elasticsearch.get(cluster, "/_cat/indices?format=json") do
-      prefix = to_string(prefix)
+      prefix = prefix |> to_string() |> Regex.escape()
+      {:ok, regex} = Regex.compile("^#{prefix}-[0-9]+$")
 
       indexes =
         indexes
         |> Enum.map(& &1["index"])
-        |> Enum.filter(&String.starts_with?(&1, prefix))
+        |> Enum.filter(&Regex.match?(regex, &1))
         |> Enum.sort()
 
       {:ok, indexes}

--- a/lib/elasticsearch/indexing/index.ex
+++ b/lib/elasticsearch/indexing/index.ex
@@ -287,6 +287,6 @@ defmodule Elasticsearch.Index do
   end
 
   defp system_timestamp do
-    DateTime.to_unix(DateTime.utc_now())
+    DateTime.to_unix(DateTime.utc_now(), :microseconds)
   end
 end

--- a/test/elasticsearch/indexing/index_test.exs
+++ b/test/elasticsearch/indexing/index_test.exs
@@ -16,7 +16,7 @@ defmodule Elasticsearch.IndexTest do
       {:ok,
        %HTTPoison.Response{
          status_code: 200,
-         body: [%{"index" => "index-name"}]
+         body: [%{"index" => "index-123"}]
        }}
     end
 


### PR DESCRIPTION
All indices are deleted with the index name as the prefix, but if we have 'items' and 'items_test' it will also wipe out 'items_test', adding a dash to the filter will solve this problem in all cases as all indices are named 'items-[0-9]+' .