### PR TITLE
Fix :default_options config name

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ config :my_app, MyApp.ElasticsearchCluster,
   }
 ```
 
+#### Specifying HTTPoison Options
+
+```
+config :my_app, MyApp.ElasticsearchCluster,
+  default_options: [
+    timeout: 5_000,
+    recv_timeout: 5_000,
+    hackney: [pool: :pool_name]
+  ]
+```
+
 ## Protocols and Behaviours
 
 #### Elasticsearch.Store
@@ -120,7 +131,7 @@ defmodule MyApp.ElasticsearchStore do
   @behaviour Elasticsearch.Store
 
   import Ecto.Query
-  
+
   alias MyApp.Repo
 
   @impl true

--- a/lib/elasticsearch/api/http.ex
+++ b/lib/elasticsearch/api/http.ex
@@ -12,7 +12,7 @@ defmodule Elasticsearch.API.HTTP do
       process_url(url, config),
       process_request_body(data, config),
       headers(config),
-      opts ++ Map.get(config, :default_opts, [])
+      opts ++ Map.get(config, :default_options, [])
     )
     |> process_response(config)
   end

--- a/lib/elasticsearch/cluster/cluster.ex
+++ b/lib/elasticsearch/cluster/cluster.ex
@@ -98,7 +98,7 @@ defmodule Elasticsearch.Cluster do
         username: "username",
         password: "password",
         default_headers: [{"authorization", "custom-value"}],
-        default_opts: [ssl: [{:versions, [:'tlsv1.2']}],
+        default_options: [ssl: [{:versions, [:'tlsv1.2']}],
         indexes: %{
           posts: %{
             settings: "priv/elasticsearch/posts.json",


### PR DESCRIPTION
There is a typo in `Elasticsearch.API.HTTP` module where the `:default_options` config variable is named as `default_opts`.
