### PR TITLE
rename microseconds to microsecond

### DIFF
--- a/lib/elasticsearch/indexing/index.ex
+++ b/lib/elasticsearch/indexing/index.ex
@@ -288,6 +288,6 @@ defmodule Elasticsearch.Index do
   end
 
   defp system_timestamp do
-    DateTime.to_unix(DateTime.utc_now(), :microseconds)
+    DateTime.to_unix(DateTime.utc_now(), :microsecond)
   end
 end


### PR DESCRIPTION
Using `microseconds` time unit is deprecated in Elixir 1.8:

```elixir
warning: deprecated time unit: :microseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
  (elixir) lib/calendar/datetime.ex:535: DateTime.to_unix/2
  (elasticsearch) lib/elasticsearch/indexing/index.ex:287: Elasticsearch.Index.build_name/1
  (elasticsearch) lib/elasticsearch/indexing/index.ex:31: Elasticsearch.Index.hot_swap/2
```