### PR TITLE
[#60] Add Elasticsearch.post_document/3

### DIFF
--- a/lib/elasticsearch.ex
+++ b/lib/elasticsearch.ex
@@ -47,6 +47,36 @@ defmodule Elasticsearch do
   end
 
   @doc """
+  Creates a document in a given index. Use this function when your documents
+  do not have IDs or you want to use Elasticsearch's automatic ID generation.
+
+  https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation
+
+  The document must implement the `Elasticsearch.Document`. protocol.
+
+  ## Example
+
+
+      Index.create_from_file(Cluster, "posts-1", "test/support/settings/posts.json")
+      Elasticsearch.post_document(Cluster, %Post{title: "Post"}, "posts-1")
+      # => {:ok,
+      # =>   %{
+      # =>     "_id" => "W0tpsmIBdwcYyG50zbta",
+      # =>     "_index" => "posts-1",
+      # =>     "_primary_term" => 1,
+      # =>     "_seq_no" => 0,
+      # =>     "_shards" => %{"failed" => 0, "successful" => 1, "total" => 2},
+      # =>     "_type" => "_doc",
+      # =>     "_version" => 1,
+      # =>     "result" => "created"
+      # =>   }}
+  """
+  @spec post_document(Cluster.t(), Document.t(), index_name) :: response
+  def post_document(cluster, document, index) do
+    post(cluster, document_url(document, index), Document.encode(document))
+  end
+
+  @doc """
   Same as `put_document/2`, but raises on errors.
 
   ## Example

--- a/test/elasticsearch_test.exs
+++ b/test/elasticsearch_test.exs
@@ -21,6 +21,8 @@ defmodule ElasticsearchTest do
 
   describe ".put_document/3" do
     test "routing meta-field is included if specified in Document" do
+      Elasticsearch.delete(Cluster, "/posts-routing")
+
       assert :ok =
                Elasticsearch.Index.create_from_file(
                  Cluster,
@@ -43,6 +45,44 @@ defmodule ElasticsearchTest do
                  %Comment{id: 2, body: "Example Comment", author: "Jane Smith", post_id: 1},
                  "posts-routing"
                )
+
+      Elasticsearch.delete(Cluster, "/posts-routing")
+    end
+  end
+
+  describe ".post_document/3" do
+    # GitHub: https://github.com/infinitered/elasticsearch-elixir/issues/60
+    @tag timeout: :infinity
+    @tag :regression
+    test "does not post ID when ID is nil" do
+      Elasticsearch.delete(Cluster, "/posts-id")
+
+      assert :ok =
+               Elasticsearch.Index.create_from_file(
+                 Cluster,
+                 "posts-id",
+                 "test/support/settings/posts.json"
+               )
+
+      assert {:ok, _} =
+               Elasticsearch.post_document(
+                 Cluster,
+                 %Post{title: "Example Post", author: "John Smith"},
+                 "posts-id"
+               )
+
+      Elasticsearch.Index.refresh!(Cluster, "posts-id")
+      {:ok, index} = Elasticsearch.get(Cluster, "/posts-id/_search")
+
+      assert get_in(index, ["hits", "hits", Access.at(0), "_id"]) != nil
+
+      assert get_in(index, ["hits", "hits", Access.at(0), "_source"]) == %{
+               "author" => "John Smith",
+               "doctype" => %{"name" => "post"},
+               "title" => "Example Post"
+             }
+
+      Elasticsearch.delete(Cluster, "/posts-id")
     end
   end
 end


### PR DESCRIPTION
You must post documents to the API in order for Elasticsearch's
automatic ID generation to work.

See [the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation) for more details.

Closes #60.