### PR TITLE
Add an ability to customize bulk api url

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ config :my_app, MyApp.ElasticsearchCluster,
       bulk_action: "create",
 
       # Path to bulk api url. Should start with a slash.
-      # You may need to use `/_doc/_bulk` for older ElasticSearch versions.
-      bulk_path: "/_bulk"
+      # You may need to use `/_bulk` for newer ElasticSearch versions.
+      bulk_path: "/_doc/_bulk"
     }
   }
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ config :my_app, MyApp.ElasticsearchCluster,
 
       # By default bulk indexing uses the "create" action. To allow existing
       # documents to be replaced, use the "index" action instead.
-      bulk_action: "create"
+      bulk_action: "create",
+
+      # Path to bulk api url. Should start with a slash.
+      # You may need to use `/_doc/_bulk` for older ElasticSearch versions.
+      bulk_path: "/_bulk"
     }
   }
 ```
@@ -207,9 +211,9 @@ As AWS does not provide credentials' based http authentication, you can use the 
 To use this, just add `sigaws` to your dependencies and add this to your configuration:
 
 ```elixir
-# Add to deps 
+# Add to deps
 def deps do
-  [          
+  [
     # ...
     {:sigaws, ">= 0.0.0"}
   ]

--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -100,7 +100,7 @@ defmodule Elasticsearch.Index.Bulk do
     bulk_page_size = index_config[:bulk_page_size] || 5000
     bulk_wait_interval = index_config[:bulk_wait_interval] || 0
     action = index_config[:bulk_action] || "create"
-    bulk_path = index_config[:bulk_path] || "/_bulk"
+    bulk_path = index_config[:bulk_path] || "/_doc/_bulk"
 
     errors =
       store.transaction(fn ->


### PR DESCRIPTION
New OpenSearch (what AWS using as well) completely removed types in urls so old url with `_doc` won't work at all. 

And it's optional in newer ElasticSearch (since v7 I think). 

This PR adds an ability to set custom bulk url postfix and defaults to the new `/{index}/_bulk` url schema.  

Other Elixir ES clients using new url schema only already. Let me know what you think. 