### PR TITLE
Update bulk.ex with no types

### DIFF
--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -121,7 +121,7 @@ defmodule Elasticsearch.Index.Bulk do
   end
 
   defp put_bulk_page(config, index_name, items) when is_list(items) do
-    Elasticsearch.put(config, "/#{index_name}/_doc/_bulk", Enum.join(items))
+    Elasticsearch.put(config, "/#{index_name}/_bulk", Enum.join(items))
   end
 
   defp collect_errors({:ok, %{"errors" => true} = response}, errors, action) do


### PR DESCRIPTION
ElasticSearch 7.x [1] already described the removal of mapping types. For the case of bulk endpoints:

> Types should also no longer appear in the body of requests. The following example of bulk indexing omits the type both in the URL, and in the individual bulk commands:

[1] https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html

This commit removes the `/_doc/` part of the URL when making Bulk uploads as part of the `hot_swap_index` function.

Fixes https://github.com/danielberkompas/elasticsearch-elixir/issues/113